### PR TITLE
✨ScrollToTopButton rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ Example:
   </ScreenFrame>
 </ThemeContext>
 ```
+![ScrollToTopButton](https://user-images.githubusercontent.com/110123778/195233320-e8116395-06a9-4ce2-92ca-8940e07ea40f.gif)
 
 ### Checkbox
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,27 @@ This button takes a `target` prop, which can be either a Number or a Ref to anot
 </ThemeContext>
 ```
 
+#### ScrollToTopButton
+
+This is a pre-baked `ScrollToButton` that handles its own styling and functionality. As a result its implimentation is as simple as adding `<ScrollToTopButton/>` anywhere in your hierarchy.
+
+Example:
+
+```jsx
+<ThemeContext theme={darkTheme}>
+  <ScrollToTopButton />
+  <ScreenFrame>
+    <PageBody>
+      <TextContent>This is the top of the page!</TextContent>
+      <PageSplashSimulator />
+      <PageSplashSimulator />
+      <PageSplashSimulator />
+      <PageSplashSimulator />
+    </PageBody>
+  </ScreenFrame>
+</ThemeContext>
+```
+
 ### Checkbox
 
 A custom Checkbox component animated with `Framer Motion` and leveraging `react-aria` for accessibility. It will use your Theme's colors.

--- a/src/components/Containers/ScreenFrame/ScreenFrame.stories.tsx
+++ b/src/components/Containers/ScreenFrame/ScreenFrame.stories.tsx
@@ -52,7 +52,7 @@ export const PopulatedPage: Story = () => (
       <CenteredCard>Test Card</CenteredCard>
       <PageSplashSimulator backgroundColor="#a4d4ff"></PageSplashSimulator>
       <Navbar>
-        <ScrollToButton target={0}>Return to Top</ScrollToButton>
+        <ScrollToButton scrollTarget={0}>Return to Top</ScrollToButton>
       </Navbar>
       <PageBody>
         <Title>Title</Title>

--- a/src/components/Inputs/Button/Button.tsx
+++ b/src/components/Inputs/Button/Button.tsx
@@ -31,12 +31,14 @@ export interface ButtonProps extends AriaButtonProps {
   visible?: boolean;
   display?: boolean;
   secondaryColor?: boolean;
+  unstyled?: boolean;
 }
 
 export const Button: React.FC<ButtonProps> = ({
   visible,
   display,
   secondaryColor,
+  unstyled,
   ...rest
 }) => {
   const ref = React.useRef(null);
@@ -53,7 +55,15 @@ export const Button: React.FC<ButtonProps> = ({
     ? SemanticColors.secondaryDisabled
     : SemanticColors.primaryDisabled;
 
-  return (
+  return unstyled ? (
+    <StyledButton
+      display={display ?? true}
+      visible={visible ?? true}
+      ref={ref}
+      {...rest}
+      {...buttonProps}
+    />
+  ) : (
     <StyledButton
       initial={{
         scale: 1,

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
@@ -8,15 +8,37 @@ import { ScrollToTopButton } from "./ScrollToTopButton/ScrollToTopButton";
 import { ScreenFrame } from "../../../Containers/ScreenFrame/ScreenFrame";
 import { PageBody } from "../../../Containers/PageBody/PageBody";
 import { TextContent } from "../../../Displays/TextContent/TextContent";
+import styled from "@emotion/styled";
 
 export default {
   title: "ScrollToButton",
   component: ScrollToButton,
 };
 
-export const Primary: Story = () => (
+const ScrollToTopButtonLeft = styled(ScrollToTopButton)`
+  bottom: 1em;
+  right: unset;
+  left: 1em;
+`;
+
+export const ScrollToTop: Story = () => (
   <ThemeContext theme={darkTheme}>
     <ScrollToTopButton />
+    <ScreenFrame>
+      <PageBody>
+        <TextContent>This is the top of the page!</TextContent>
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+      </PageBody>
+    </ScreenFrame>
+  </ThemeContext>
+);
+
+export const ScrollToTopAlt: Story = () => (
+  <ThemeContext theme={darkTheme}>
+    <ScrollToTopButtonLeft />
     <ScreenFrame>
       <PageBody>
         <TextContent>This is the top of the page!</TextContent>

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
@@ -2,9 +2,12 @@ import React from "react";
 import { Story } from "@storybook/react";
 import { darkTheme, lightTheme } from "../../../../consts/theme";
 import { ScrollToButton } from "./ScrollToButton";
-import { Navbar } from "../../../Containers/Navbar/Navbar";
 import { PageSplashSimulator } from "../../../../consts/testComponents";
 import { ThemeContext } from "../../../ThemeContext";
+import { ScrollToTopButton } from "./ScrollToTopButton/ScrollToTopButton";
+import { ScreenFrame } from "../../../Containers/ScreenFrame/ScreenFrame";
+import { PageBody } from "../../../Containers/PageBody/PageBody";
+import { TextContent } from "../../../Displays/TextContent/TextContent";
 
 export default {
   title: "ScrollToButton",
@@ -13,15 +16,15 @@ export default {
 
 export const Primary: Story = () => (
   <ThemeContext theme={darkTheme}>
-    <Navbar>
-      <ScrollToButton scrollTarget={0}>Scroll to Top</ScrollToButton>
-      <p>
-        This text should leave space for the scroll button even if it isn't
-        visible.
-      </p>
-    </Navbar>
-    <PageSplashSimulator />
-    <PageSplashSimulator />
-    <PageSplashSimulator />
+    <ScrollToTopButton />
+    <ScreenFrame>
+      <PageBody>
+        <TextContent>This is the top of the page!</TextContent>
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+      </PageBody>
+    </ScreenFrame>
   </ThemeContext>
 );

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
@@ -2,28 +2,26 @@ import React from "react";
 import { Story } from "@storybook/react";
 import { darkTheme, lightTheme } from "../../../../consts/theme";
 import { ScrollToButton } from "./ScrollToButton";
+import { Navbar } from "../../../Containers/Navbar/Navbar";
 import { PageSplashSimulator } from "../../../../consts/testComponents";
 import { ThemeContext } from "../../../ThemeContext";
-import { ScrollToTopButton } from "./ScrollToTopButton/ScrollToTopButton";
-import { TextContent } from "../../../Displays/TextContent/TextContent";
-import { ScreenFrame } from "../../../Containers/ScreenFrame/ScreenFrame";
-import { PageBody } from "../../../Containers/PageBody/PageBody";
 
 export default {
   title: "ScrollToButton",
   component: ScrollToButton,
 };
 
-export const ScrollToTop: Story = () => (
+export const Primary: Story = () => (
   <ThemeContext theme={darkTheme}>
-    <ScreenFrame>
-      <PageBody>
-        <ScrollToTopButton />
-        <TextContent>This is the top of the page!</TextContent>
-        <PageSplashSimulator />
-        <PageSplashSimulator />
-        <PageSplashSimulator />
-      </PageBody>
-    </ScreenFrame>
+    <Navbar>
+      <ScrollToButton scrollTarget={0}>Scroll to Top</ScrollToButton>
+      <p>
+        This text should leave space for the scroll button even if it isn't
+        visible.
+      </p>
+    </Navbar>
+    <PageSplashSimulator />
+    <PageSplashSimulator />
+    <PageSplashSimulator />
   </ThemeContext>
 );

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
@@ -2,24 +2,20 @@ import React from "react";
 import { Story } from "@storybook/react";
 import { darkTheme, lightTheme } from "../../../../consts/theme";
 import { ScrollToButton } from "./ScrollToButton";
-import { Navbar } from "../../../Containers/Navbar/Navbar";
 import { PageSplashSimulator } from "../../../../consts/testComponents";
 import { ThemeContext } from "../../../ThemeContext";
+import { ScrollToTopButton } from "./ScrollToTopButton/ScrollToTopButton";
+import { TextContent } from "../../../Displays/TextContent/TextContent";
 
 export default {
   title: "ScrollToButton",
   component: ScrollToButton,
 };
 
-export const Primary: Story = () => (
+export const ScrollToTop: Story = () => (
   <ThemeContext theme={darkTheme}>
-    <Navbar>
-      <ScrollToButton target={0}>Scroll to Top</ScrollToButton>
-      <p>
-        This text should leave space for the scroll button even if it isn't
-        visible.
-      </p>
-    </Navbar>
+    <ScrollToTopButton />
+    <TextContent>This is the top of the page!</TextContent>
     <PageSplashSimulator />
     <PageSplashSimulator />
     <PageSplashSimulator />

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.stories.tsx
@@ -6,6 +6,8 @@ import { PageSplashSimulator } from "../../../../consts/testComponents";
 import { ThemeContext } from "../../../ThemeContext";
 import { ScrollToTopButton } from "./ScrollToTopButton/ScrollToTopButton";
 import { TextContent } from "../../../Displays/TextContent/TextContent";
+import { ScreenFrame } from "../../../Containers/ScreenFrame/ScreenFrame";
+import { PageBody } from "../../../Containers/PageBody/PageBody";
 
 export default {
   title: "ScrollToButton",
@@ -14,10 +16,14 @@ export default {
 
 export const ScrollToTop: Story = () => (
   <ThemeContext theme={darkTheme}>
-    <ScrollToTopButton />
-    <TextContent>This is the top of the page!</TextContent>
-    <PageSplashSimulator />
-    <PageSplashSimulator />
-    <PageSplashSimulator />
+    <ScreenFrame>
+      <PageBody>
+        <ScrollToTopButton />
+        <TextContent>This is the top of the page!</TextContent>
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+        <PageSplashSimulator />
+      </PageBody>
+    </ScreenFrame>
   </ThemeContext>
 );

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.tsx
@@ -2,13 +2,13 @@ import { Button, ButtonProps } from "../Button";
 import React from "react";
 
 interface ScrollToButtonProps extends ButtonProps {
-  scrollAnchor: number | React.MutableRefObject<any>;
+  scrollTarget: number | React.MutableRefObject<any>;
   behavior?: "smooth" | "auto";
 }
 
 export const ScrollToButton: React.FC<ScrollToButtonProps> = ({
   behavior = "smooth",
-  scrollAnchor: scrollTarget,
+  scrollTarget,
   ...rest
 }) => {
   const scroll = (

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.tsx
@@ -1,51 +1,32 @@
-import styled from "@emotion/styled";
-import { useState } from "react";
-import { SemanticColors } from "../../../../types/Color";
-import { Button } from "../Button";
+import { Button, ButtonProps } from "../Button";
 import React from "react";
 
-interface ScrollToButtonProps {
-  target: number | React.MutableRefObject<any>;
+interface ScrollToButtonProps extends ButtonProps {
+  scrollAnchor: number | React.MutableRefObject<any>;
   behavior?: "smooth" | "auto";
-  children?: React.ReactNode;
 }
 
 export const ScrollToButton: React.FC<ScrollToButtonProps> = ({
   behavior = "smooth",
-  target,
-  children,
+  scrollAnchor: scrollTarget,
+  ...rest
 }) => {
-  const [visible, setVisible] = useState(false);
-
-  const toggleVisible = () => {
-    const scrolled = document.documentElement.scrollTop;
-    if (scrolled > 300) {
-      setVisible(true);
-    } else if (scrolled <= 300) {
-      setVisible(false);
-    }
-  };
-
   const scroll = (
-    target: number | React.MutableRefObject<any>,
+    scrollTarget: number | React.MutableRefObject<any>,
     behavior: "smooth" | "auto"
   ) => {
     console.log("scrolling");
-    if (typeof target === "number") {
+    if (typeof scrollTarget === "number") {
       window.scrollTo({
-        top: target,
+        top: scrollTarget,
         behavior: behavior,
       });
     } else {
-      target?.current?.scrollIntoView?.();
+      scrollTarget?.current?.scrollIntoView?.();
     }
   };
 
-  window.addEventListener("scroll", toggleVisible);
-
   return (
-    <Button onPress={() => scroll(target, behavior)} visible={visible}>
-      {children}
-    </Button>
+    <Button onPress={() => scroll(scrollTarget, behavior)} {...rest}></Button>
   );
 };

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToButton.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToButton.tsx
@@ -1,7 +1,7 @@
 import { Button, ButtonProps } from "../Button";
 import React from "react";
 
-interface ScrollToButtonProps extends ButtonProps {
+export interface ScrollToButtonProps extends ButtonProps {
   scrollTarget: number | React.MutableRefObject<any>;
   behavior?: "smooth" | "auto";
 }

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
@@ -13,10 +13,6 @@ const StyledScrollToTopButton = styled(ScrollToButton)`
   font-size: 2em;
   padding: 0;
   background-color: transparent;
-
-  :hover {
-    background-color: transparent;
-  }
 `;
 
 export const ScrollToTopButton: React.FC<
@@ -32,6 +28,8 @@ export const ScrollToTopButton: React.FC<
       setVisible(false);
     }
   };
+
+  const upArrow = <>&uarr;</>;
 
   window.addEventListener("scroll", toggleVisible);
 
@@ -50,7 +48,7 @@ export const ScrollToTopButton: React.FC<
               },
             }}
           >
-            &uarr;
+            {upArrow}
           </motion.div>
         </StyledScrollToTopButton>
       )}

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
@@ -2,14 +2,7 @@ import styled from "@emotion/styled";
 import { motion, AnimatePresence } from "framer-motion/dist/framer-motion";
 import React from "react";
 import { SemanticColors } from "../../../../../types/Color";
-import { ScrollToButton } from "../ScrollToButton";
-
-enum Position {
-  TopLeft,
-  TopRight,
-  BottomLeft,
-  BottomRight,
-}
+import { ScrollToButton, ScrollToButtonProps } from "../ScrollToButton";
 
 const StyledScrollToTopButton = styled(ScrollToButton)`
   position: fixed;
@@ -26,7 +19,9 @@ const StyledScrollToTopButton = styled(ScrollToButton)`
   }
 `;
 
-export const ScrollToTopButton: React.FC = () => {
+export const ScrollToTopButton: React.FC<
+  Omit<ScrollToButtonProps, "scrollTarget">
+> = (buttonProps) => {
   const [visible, setVisible] = React.useState(false);
 
   const toggleVisible = () => {
@@ -43,7 +38,7 @@ export const ScrollToTopButton: React.FC = () => {
   return (
     <AnimatePresence>
       {visible && (
-        <StyledScrollToTopButton unstyled scrollTarget={0}>
+        <StyledScrollToTopButton unstyled scrollTarget={0} {...buttonProps}>
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
@@ -43,7 +43,7 @@ export const ScrollToTopButton: React.FC = () => {
   return (
     <AnimatePresence>
       {visible && (
-        <StyledScrollToTopButton scrollTarget={0}>
+        <StyledScrollToTopButton unstyled scrollTarget={0}>
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}

--- a/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
+++ b/src/components/Inputs/Button/ScrollToButton/ScrollToTopButton/ScrollToTopButton.tsx
@@ -1,4 +1,64 @@
 import styled from "@emotion/styled";
+import { motion, AnimatePresence } from "framer-motion/dist/framer-motion";
+import React from "react";
+import { SemanticColors } from "../../../../../types/Color";
 import { ScrollToButton } from "../ScrollToButton";
 
-const StyledScrollToTopButton = styled(ScrollToButton)``;
+enum Position {
+  TopLeft,
+  TopRight,
+  BottomLeft,
+  BottomRight,
+}
+
+const StyledScrollToTopButton = styled(ScrollToButton)`
+  position: fixed;
+  bottom: 1em;
+  right: 1em;
+  border-radius: 100%;
+  text-align: center;
+  font-size: 2em;
+  padding: 0;
+  background-color: transparent;
+
+  :hover {
+    background-color: transparent;
+  }
+`;
+
+export const ScrollToTopButton: React.FC = () => {
+  const [visible, setVisible] = React.useState(false);
+
+  const toggleVisible = () => {
+    const scrolled = document.documentElement.scrollTop;
+    if (scrolled > 300) {
+      setVisible(true);
+    } else if (scrolled <= 300) {
+      setVisible(false);
+    }
+  };
+
+  window.addEventListener("scroll", toggleVisible);
+
+  return (
+    <AnimatePresence>
+      {visible && (
+        <StyledScrollToTopButton scrollTarget={0}>
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            whileHover={{
+              color: `var(${SemanticColors.primary})`,
+              transition: {
+                duration: 0.2,
+              },
+            }}
+          >
+            &uarr;
+          </motion.div>
+        </StyledScrollToTopButton>
+      )}
+    </AnimatePresence>
+  );
+};


### PR DESCRIPTION
# Summary
- Reworked the `ScrollToTopButton` to handle its own styling, animations, and functionality.

# Changes
- `ScrollToTopButton` now presents as an up arrow fixed in the bottom right corner of the screen, which will be invisible until the user has scrolled 300 or more pixels down.
- On hover, `ScrollToTopButton` will change its color to your theme's primary color.

# Preview
![ScrollToTopButton](https://user-images.githubusercontent.com/110123778/195233798-f27898d6-ed79-4edc-8fa1-a7acf7553972.gif)
